### PR TITLE
Add support for automatically inferring inverse relations

### DIFF
--- a/src/decorators/load/load.decorator.spec.ts
+++ b/src/decorators/load/load.decorator.spec.ts
@@ -429,4 +429,55 @@ describe("Load Decorator", () => {
 			parentKey: "teamId",
 		});
 	});
+
+	it("should automatically infer inverse relationships when provided", () => {
+		class Post {
+			id: number;
+			userId: number;
+		}
+
+		class User {
+			id: number;
+
+			@Load(() => Post, {
+				key: "id",
+				parentKey: "userId",
+				handler: "LOAD_POSTS_BY_USER_ID",
+				inverseField: "user",
+				inverseHandler: "LOAD_USER_BY_POST_ID",
+				inverseRelationType: RelationType.OneToOne,
+			})
+			post: Post;
+		}
+
+		LazyMetadataContainer.loadRelationshipMetadata();
+
+		const userRelations = LazyMetadataContainer.loadedRelationships.get(User);
+		expect(userRelations).toBeDefined();
+
+		const postMetadata = userRelations?.get("post");
+		expect(postMetadata).toEqual({
+			key: "id",
+			parentKey: "userId",
+			handler: "LOAD_POSTS_BY_USER_ID",
+			type: RelationType.OneToOne,
+			parent: User,
+			child: Post,
+			isArray: false,
+		});
+
+		const postRelations = LazyMetadataContainer.loadedRelationships.get(Post);
+		expect(postRelations).toBeDefined();
+
+		const userMetadata = postRelations?.get("user");
+		expect(userMetadata).toEqual({
+			key: "userId",
+			parentKey: "id",
+			handler: "LOAD_USER_BY_POST_ID",
+			type: RelationType.OneToOne,
+			parent: Post,
+			child: User,
+			isArray: false,
+		});
+	});
 });

--- a/src/decorators/load/load.decorator.ts
+++ b/src/decorators/load/load.decorator.ts
@@ -1,5 +1,5 @@
 import type { Type } from "@nestjs/common";
-import { ChildFN } from "../../types/dataloader.types";
+import { ChildFN, RelationType } from "../../types/dataloader.types";
 import { Paths } from "../../types/paths.type";
 import { LazyMetadataContainer } from "../../utils";
 
@@ -7,10 +7,13 @@ interface LoadOptions<Child, Parent> {
 	key: Paths<Parent>;
 	parentKey: Paths<Child>;
 	handler: string;
+	inverseField?: Paths<Child>;
+	inverseHandler?: string;
+	inverseRelationType?: RelationType;
 }
 
 export function Load<Child, Parent = any>(child: ChildFN<Child>, options: LoadOptions<Child, Parent>) {
-	const { key, parentKey, handler } = options;
+	const { key, parentKey, handler, inverseField, inverseHandler, inverseRelationType } = options;
 	return (target: NonNullable<any>, propertyKey: string) => {
 		const parent = () => target.constructor as Type;
 
@@ -22,5 +25,18 @@ export function Load<Child, Parent = any>(child: ChildFN<Child>, options: LoadOp
 			explicitChildFN: child,
 			originalFieldName: propertyKey,
 		});
+
+		if (inverseField && inverseHandler && inverseRelationType) {
+			const childType = child() as Type;
+			LazyMetadataContainer.addRelationshipMetadata({
+				key: parentKey as string,
+				parentKey: key as string,
+				handler: inverseHandler,
+				parentFN: () => childType,
+				explicitChildFN: () => parent(),
+				originalFieldName: inverseField as string,
+				type: inverseRelationType,
+			});
+		}
 	};
 }

--- a/src/utils/lazy-metadata-container/lazy-metadata-container.ts
+++ b/src/utils/lazy-metadata-container/lazy-metadata-container.ts
@@ -57,6 +57,26 @@ export class LazyMetadataContainer {
 			}
 
 			LazyMetadataContainer.loadedRelationships.get(parent)?.set(unloadedRelationship.originalFieldName, metadata);
+
+			if (unloadedRelationship.inverseField && unloadedRelationship.inverseHandler && unloadedRelationship.inverseRelationType) {
+				const inverseMetadata = {
+					parent: metadata.child,
+					child: metadata.parent,
+					isArray: unloadedRelationship.inverseRelationType === RelationType.OneToMany,
+					key: metadata.parentKey,
+					parentKey: metadata.key,
+					handler: unloadedRelationship.inverseHandler,
+					type: unloadedRelationship.inverseRelationType,
+				};
+
+				const isInverseRelationAdded = LazyMetadataContainer.loadedRelationships.has(inverseMetadata.parent);
+
+				if (!isInverseRelationAdded) {
+					LazyMetadataContainer.loadedRelationships.set(inverseMetadata.parent, new Map());
+				}
+
+				LazyMetadataContainer.loadedRelationships.get(inverseMetadata.parent)?.set(unloadedRelationship.inverseField, inverseMetadata);
+			}
 		}
 	}
 


### PR DESCRIPTION
Add support for automatically inferring inverse relations between entities based on existing metadata.

* Add `inverseField`, `inverseHandler`, and `inverseRelationType` to `LoadOptions` interface in `src/decorators/load/load.decorator.ts`.
* Modify `Load` decorator to handle inverse relationship inference in `src/decorators/load/load.decorator.ts`.
* Update `LazyMetadataContainer.addRelationshipMetadata` call to include inverse relationship metadata in `src/decorators/load/load.decorator.ts`.
* Modify `loadRelationshipMetadata` method in `src/utils/lazy-metadata-container/lazy-metadata-container.ts` to handle inverse relationship inference.
* Add logic to check for `inverseField`, `inverseHandler`, and `inverseRelationType` in relationship metadata in `src/utils/lazy-metadata-container/lazy-metadata-container.ts`.
* Automatically create inverse relationship metadata if provided in `src/utils/lazy-metadata-container/lazy-metadata-container.ts`.
* Add test cases for automatic inverse relationship inference in `src/decorators/load/load.decorator.spec.ts`.
* Verify that inverse relationships are correctly inferred and added to `LazyMetadataContainer` in `src/decorators/load/load.decorator.spec.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gabrieljsilva/nestjs-decorated-dataloaders/pull/4?shareId=e200cbef-7a39-4929-89e5-d5d7a301c8e9).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced relationship loading decorator to support automatic inference of inverse relationships
	- Added support for specifying inverse relationship details during metadata configuration

- **Tests**
	- Added new test case to verify inverse relationship metadata inference and configuration

The changes improve the flexibility and robustness of relationship metadata handling in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->